### PR TITLE
ENVSETUP: Unalias user aliases when script is sourced

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -
 
+unalias -a
+
 _FORMAT_PATTERN='£-£'
 _SITECONFSAMPLE_PATH=$(dirname $(realpath ${BASH_SOURCE}))
 


### PR DESCRIPTION
If user aliases some commands like rm,
script may not work.

To make this more reproductible its safe to unalias all of them.

Change-Id: I8e388b3700f8da76151bc9d5ba35f1a6b119b398
Forwarded: https://github.com/STMicroelectronics/meta-st-scripts
Signed-off-by: Philippe Coval <rzr@users.sf.net>